### PR TITLE
chore: removes Canto.

### DIFF
--- a/examples/react/src/components/ConnectWallet.tsx
+++ b/examples/react/src/components/ConnectWallet.tsx
@@ -11,7 +11,6 @@ const network = {
   80001: "Mumbai",
   11297108109: "Palm",
   11297108099: "PalmTestnet",
-  7700: "Canto",
 };
 const ConnectWallet: React.FC = () => {
   const injectedConnector = useMemo(


### PR DESCRIPTION
This doesn't seem to fully remove canto from the sdk yet, since `sdk/src/apis/aspen/aspen.ts` is being auto-generated from `@monaxlabs/phloem` dep which still contains canto. Is this a circular dependency (since I couldn't make the aspen build pass without having a new version of the sdk first) or I'm missing something?